### PR TITLE
Fix hang forever on failed image download

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,17 @@ library may break unexpectedly.
 using `aiohttp`, requiring a `ClientSession`.
 
 ## Installation
+streetlevel is available on PyPI:
+
 ```sh
 pip install streetlevel
+```
+
+macOS users may need to install [additional dependencies](https://github.com/LeoHsiao1/pyexiv2/blob/master/docs/Tutorial.md#faq):
+
+```sh
+brew install gettext
+brew install inih
 ```
 
 ## Example


### PR DESCRIPTION
I've found some panos that at high zoom hang forever on the download, seemingly one of the images is throwing an error and async wait_for hangs forever.

This is a minimal repro that hangs forever without this patch but works fine with it.

```py
#!/usr/bin/env python3
import asyncio
from aiohttp import ClientSession
from streetlevel.streetview import find_panorama_async, get_panorama_async

LATITUDE = 52.37989
LONGITUDE = 4.90001


async def test_panorama_download():
    """Test downloading a panorama to verify the fix works."""    
    async with ClientSession() as session:
        pano = await find_panorama_async(LATITUDE, LONGITUDE, session)
        await get_panorama_async(pano, session, zoom=5)

asyncio.run(test_panorama_download())
```