### PR TITLE
Add retry logic for tile fetch

### DIFF
--- a/streetlevel/util.py
+++ b/streetlevel/util.py
@@ -174,9 +174,13 @@ async def download_files_async(urls: List[str], session: ClientSession = None) -
     session = session if session else ClientSession()
 
     async def download_one(url: str) -> bytes:
-        async with session.get(url) as response:
-            response.raise_for_status()
-            return await response.read()
+        for _ in range(4):
+            async with session.get(url) as response:
+                if response.status == 200:
+                    return await response.read()
+                if 400 <= response.status < 500:
+                    response.raise_for_status()
+        response.raise_for_status()
 
     tasks = [download_one(url) for url in urls]
     data = await asyncio.gather(*tasks)


### PR DESCRIPTION

hmm it seems like with the new endpoint, there is a high failure rate, especially when zoom = 5. Hence, proposing a retry per tile fetch.

**Test output before adding retry:**
    run 1: pass
    run 2: fail (503, message='Service Unavailable', url='https://streetviewpixels-pa.googleapis.com/v1/tile?cb_client=maps_sv.tactile&panoid=3ALWqIbn6Zm_a9wvWalNDQ&x=1&y=7&zoom=5')
    run 3: fail (503, message='Service Unavailable', url='https://streetviewpixels-pa.googleapis.com/v1/tile?cb_client=maps_sv.tactile&panoid=3ALWqIbn6Zm_a9wvWalNDQ&x=6&y=6&zoom=5')
    run 4: fail (503, message='Service Unavailable', url='https://streetviewpixels-pa.googleapis.com/v1/tile?cb_client=maps_sv.tactile&panoid=3ALWqIbn6Zm_a9wvWalNDQ&x=6&y=15&zoom=5')
    run 5: fail (503, message='Service Unavailable', url='https://streetviewpixels-pa.googleapis.com/v1/tile?cb_client=maps_sv.tactile&panoid=3ALWqIbn6Zm_a9wvWalNDQ&x=10&y=14&zoom=5')

    1/5 succeeded

**Test output after adding retry:**
    run 1: pass
    run 2: pass
    run 3: pass
    run 4: pass
    run 5: pass

    5/5 succeeded

Each run downloads a panorama at zoom=5 using download_panorama_async.